### PR TITLE
autobuild and working against NimBLE-arduino 2.1.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fqbn: esp32:esp32:esp32
           sketch-paths: |
-            - examples/GamepadExamples/CharacteristicsConfiguration/CharacteristicsConfiguration.ino
+            # - examples/GamepadExamples/CharacteristicsConfiguration/CharacteristicsConfiguration.ino # disable because  esp_base_mac_addr_set is disabled in BleCompositeHID.cpp
             - examples/GamepadExamples/DrivingControllerTest/DrivingControllerTest.ino
             - examples/GamepadExamples/FlightControllerTest/FlightControllerTest.ino
             - examples/GamepadExamples/Gamepad/Gamepad.ino

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,47 @@
+name: Compile Sketches
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  compile-sketches:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # See: https://github.com/arduino/compile-sketches#readme
+      - name: Compile sketches
+        uses: arduino/compile-sketches@v1
+        with:
+          fqbn: esp32:esp32:esp32
+          sketch-paths: |
+            - examples/GamepadExamples/CharacteristicsConfiguration/CharacteristicsConfiguration.ino
+            - examples/GamepadExamples/DrivingControllerTest/DrivingControllerTest.ino
+            - examples/GamepadExamples/FlightControllerTest/FlightControllerTest.ino
+            - examples/GamepadExamples/Gamepad/Gamepad.ino
+            - examples/GamepadExamples/IndividualAxes/IndividualAxes.ino
+            - examples/GamepadExamples/Keypad4x4/Keypad4x4.ino
+            - examples/GamepadExamples/MultipleButtonsAndHats/MultipleButtonsAndHats.ino
+            - examples/GamepadExamples/MultipleButtonsDebounce/MultipleButtonsDebounce.ino
+            - examples/GamepadExamples/MultipleButtons/MultipleButtons.ino
+            - examples/GamepadExamples/PlayerIndicators/PlayerIndicators.ino
+            - examples/GamepadExamples/PotAsAxis/PotAsAxis.ino
+            - examples/GamepadExamples/SingleButtonDebounce/SingleButtonDebounce.ino
+            - examples/GamepadExamples/SingleButton/SingleButton.ino
+            - examples/GamepadExamples/SpecialButtons/SpecialButtons.ino
+            - examples/GamepadExamples/TestAll/TestAll.ino
+            - examples/GamepadExamples/XboxXInputController/XboxXInputController.ino
+            - examples/KeyboardExamples/KeyboardLEDs/KeyboardLEDs.ino
+            - examples/KeyboardExamples/MediaKeys/MediaKeys.ino
+            - examples/KeyboardExamples/PressKey/PressKey.ino
+            - examples/MultipleDeviceExamples/DeferredReports/DeferredReports.ino
+            - examples/MultipleDeviceExamples/GamepadAndMouse/GamepadAndMouse.ino
+            - examples/MultipleDeviceExamples/GamepadMouseKeyboard/GamepadMouseKeyboard.ino
+            - examples/MultipleDeviceExamples/MouseAndKeyboard/MouseAndKeyboard.ino            
+          libraries: |
+            - name: callback
+            - name: NimBLE-Arduino
+            - source-path: .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,4 +44,5 @@ jobs:
           libraries: |
             - name: callback
             - name: NimBLE-Arduino
+            - name: Keypad
             - source-path: .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,4 +45,5 @@ jobs:
             - name: callback
             - name: NimBLE-Arduino
             - name: Keypad
+            - name: Bounce2
             - source-path: .

--- a/BleCompositeHID.cpp
+++ b/BleCompositeHID.cpp
@@ -7,7 +7,6 @@
 #include <driver/adc.h>
 #include "sdkconfig.h"
 
-
 #include "BleCompositeHID.h"
 #include "BleConnectionStatus.h"
 

--- a/BleCompositeHID.cpp
+++ b/BleCompositeHID.cpp
@@ -13,7 +13,6 @@
 #include <sstream>
 #include <iostream>
 #include <iomanip>
-#include <stdexcept>
 
 
 #if defined(CONFIG_ARDUHAL_ESP_LOG)

--- a/BleCompositeHID.cpp
+++ b/BleCompositeHID.cpp
@@ -13,7 +13,7 @@
 #include <sstream>
 #include <iostream>
 #include <iomanip>
-
+#include <stdexcept>
 
 
 #if defined(CONFIG_ARDUHAL_ESP_LOG)

--- a/BleCompositeHID.cpp
+++ b/BleCompositeHID.cpp
@@ -1,13 +1,21 @@
+#include <NimBLEDevice.h>
+#include <NimBLEUtils.h>
+#include <NimBLEServer.h>
+#include "NimBLEHIDDevice.h"
+#include "HIDTypes.h"
+#include "HIDKeyboardTypes.h"
+#include <driver/adc.h>
+#include "sdkconfig.h"
+
+
 #include "BleCompositeHID.h"
 #include "BleConnectionStatus.h"
 
 #include <sstream>
 #include <iostream>
 #include <iomanip>
-#include <NimBLEDevice.h>
-#include <NimBLEUtils.h>
-#include <NimBLEServer.h>
-#include <NimBLEHIDDevice.h>
+
+
 
 #if defined(CONFIG_ARDUHAL_ESP_LOG)
 #include "esp32-hal-log.h"
@@ -54,7 +62,7 @@ BleCompositeHID::BleCompositeHID(std::string deviceName, std::string deviceManuf
     this->deviceName = deviceName.substr(0, CONFIG_BT_NIMBLE_GAP_DEVICE_NAME_MAX_LEN - 1);
     this->deviceManufacturer = deviceManufacturer;
     this->batteryLevel = batteryLevel;
-    this->_connectionStatus = new BleConnectionStatus();
+    this->_connectionStatus = new BleConnectionStatus();   
 }
 
 BleCompositeHID::~BleCompositeHID()
@@ -140,12 +148,7 @@ void BleCompositeHID::setBatteryLevel(uint8_t level)
     this->batteryLevel = level;
     if (this->_hid)
     {
-        this->_hid->setBatteryLevel(this->batteryLevel);
-
-        if (this->isConnected())
-        {
-            this->_hid->batteryLevel()->notify();
-        }
+        this->_hid->setBatteryLevel(this->batteryLevel,this->isConnected()?true:false);
 		
         // if (this->_configuration.getAutoReport())
         // {
@@ -218,10 +221,10 @@ void BleCompositeHID::taskServer(void *pvParameter)
     // Set the report map
     uint8_t customHidReportDescriptor[hidReportDescriptorSize];
     memcpy(&customHidReportDescriptor, tempHidReportDescriptor, hidReportDescriptorSize);
-    BleCompositeHIDInstance->_hid->reportMap(&customHidReportDescriptor[0], hidReportDescriptorSize);
+    BleCompositeHIDInstance->_hid->setReportMap(&customHidReportDescriptor[0], hidReportDescriptorSize);
 
     // Set manufacturer info
-    BleCompositeHIDInstance->_hid->manufacturer()->setValue(BleCompositeHIDInstance->deviceManufacturer);
+    BleCompositeHIDInstance->_hid->setManufacturer(BleCompositeHIDInstance->deviceManufacturer);
 
     // Create device UUID
     NimBLEService *pService = pServer->getServiceByUUID(SERVICE_UUID_DEVICE_INFORMATION);
@@ -264,8 +267,8 @@ void BleCompositeHID::taskServer(void *pvParameter)
     // pCharacteristic_Hardware_Revision->setValue();
 
     // Set PnP IDs
-    BleCompositeHIDInstance->_hid->pnp(vidSource, vid, pid, guidVersion);
-    BleCompositeHIDInstance->_hid->hidInfo(0x00, 0x01);
+    BleCompositeHIDInstance->_hid->setPnp(vidSource, vid, pid, guidVersion);
+    BleCompositeHIDInstance->_hid->setHidInfo(0x00, 0x01);
 
     // NimBLEDevice::setSecurityAuth(BLE_SM_PAIR_AUTHREQ_BOND);  //BLE_SM_PAIR_AUTHREQ_SC
 	NimBLEDevice::setSecurityAuth(true, false, false); // enable bonding, no MITM, no SC
@@ -277,7 +280,7 @@ void BleCompositeHID::taskServer(void *pvParameter)
     // Start BLE advertisement
     NimBLEAdvertising *pAdvertising = pServer->getAdvertising();
     pAdvertising->setAppearance(GENERIC_HID);
-    pAdvertising->addServiceUUID(BleCompositeHIDInstance->_hid->hidService()->getUUID());
+    pAdvertising->addServiceUUID(BleCompositeHIDInstance->_hid->getHidService()->getUUID());
     pAdvertising->start();
     ESP_LOGD(LOG_TAG, "Advertising started!");
 

--- a/BleCompositeHID.h
+++ b/BleCompositeHID.h
@@ -25,13 +25,13 @@ public:
     void begin(const BLEHostConfiguration& config);
     void end();
 
-    void setBatteryLevel(uint8_t level);
     void addDevice(BaseCompositeDevice* device);
     bool isConnected();
 
     void queueDeviceDeferredReport(std::function<void()> && reportFunc);
     void sendDeferredReports();
 
+    void setBatteryLevel(uint8_t level);
     uint8_t batteryLevel;
     std::string deviceManufacturer;
     std::string deviceName;

--- a/BleConnectionStatus.cpp
+++ b/BleConnectionStatus.cpp
@@ -4,7 +4,7 @@ BleConnectionStatus::BleConnectionStatus(void)
 {
 }
 
-void BleConnectionStatus::onConnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo)
+void BleConnectionStatus::onConnect(NimBLEServer *pServer, NimBLEConnInfo& connInfo)
 {
     pServer->updateConnParams(connInfo.getConnHandle(), 6, 7, 0, 600);
     this->connected = true;

--- a/BleConnectionStatus.h
+++ b/BleConnectionStatus.h
@@ -8,13 +8,15 @@
 
 #include <NimBLEServer.h>
 #include "NimBLECharacteristic.h"
+#include "NimBLEConnInfo.h"
 
 class BleConnectionStatus : public NimBLEServerCallbacks
 {
 public:
     BleConnectionStatus(void);
-    void onConnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo) override;
-    void onDisconnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo, int reason) override;
+    void onConnect(NimBLEServer *pServer, NimBLEConnInfo& connInfo) override;
+    void onDisconnect(NimBLEServer *pServer, NimBLEConnInfo& connInfo, int reason) override;
+    //NimBLECharacteristic *inputGamepad;
     bool isConnected();
 private:
     bool connected = false;

--- a/GamepadConfiguration.cpp
+++ b/GamepadConfiguration.cpp
@@ -1,4 +1,5 @@
 #include "GamepadConfiguration.h"
+#include "HIDTypes.h"
 
 #if defined(CONFIG_ARDUHAL_ESP_LOG)
 #include "esp32-hal-log.h"

--- a/GamepadDevice.cpp
+++ b/GamepadDevice.cpp
@@ -144,10 +144,10 @@ GamepadDevice::~GamepadDevice()
 void GamepadDevice::init(NimBLEHIDDevice* hid)
 {
     // Create input characteristic to send events to the computer
-    auto input = hid->inputReport(_config.getReportId());
+    auto input = hid->getInputReport(_config.getReportId());
 
     // Create output characteristic to handle events coming from the computer
-    auto output = hid->outputReport(_config.getReportId());
+    auto output = hid->getOutputReport(_config.getReportId());
 
     // Set callbacks
     _callbacks = new GamepadCallbacks(this);

--- a/GamepadDevice.cpp
+++ b/GamepadDevice.cpp
@@ -1,6 +1,8 @@
 #include "GamepadDevice.h"
 #include "BleCompositeHID.h"
 
+#include <stdexcept>
+
 #if defined(CONFIG_ARDUHAL_ESP_LOG)
 #include "esp32-hal-log.h"
 #define LOG_TAG "GamepadDevice"

--- a/GamepadDevice.h
+++ b/GamepadDevice.h
@@ -117,6 +117,10 @@ public:
     void resetButtons();
 
     void sendGamepadReport(bool defer = false);
+
+    // callbacks
+    Signal<uint8_t> onPlayerIndicatorChanged;
+
 private:
     void sendGamepadReportImp();
 
@@ -124,8 +128,7 @@ private:
     // Output properties
     uint8_t getPlayerIndicator();
 
-    // callbacks
-    Signal<uint8_t> onPlayerIndicatorChanged;
+
 
 
 private:

--- a/KeyboardConfiguration.cpp
+++ b/KeyboardConfiguration.cpp
@@ -1,6 +1,7 @@
 #include "KeyboardConfiguration.h"
 #include "KeyboardDevice.h"
 #include "KeyboardDescriptors.h"
+#include "HIDTypes.h"
 
 KeyboardConfiguration::KeyboardConfiguration() :
     BaseCompositeDeviceConfiguration(KEYBOARD_REPORT_ID),

--- a/KeyboardDevice.cpp
+++ b/KeyboardDevice.cpp
@@ -65,9 +65,9 @@ KeyboardDevice::~KeyboardDevice()
 
 void KeyboardDevice::init(NimBLEHIDDevice* hid)
 {
-    _input = hid->inputReport(_config.getReportId());
-    _mediaInput = hid->inputReport(MEDIA_KEYS_REPORT_ID);
-    _output = hid->outputReport(_config.getReportId());
+    _input = hid->getInputReport(_config.getReportId());
+    _mediaInput = hid->getInputReport(MEDIA_KEYS_REPORT_ID);
+    _output = hid->getOutputReport(_config.getReportId());
     _callbacks = new KeyboardCallbacks(this);
     _output->setCallbacks(_callbacks);
 

--- a/MouseConfiguration.cpp
+++ b/MouseConfiguration.cpp
@@ -1,4 +1,5 @@
 #include "MouseConfiguration.h"
+#include "HIDTypes.h"
 
 MouseConfiguration::MouseConfiguration() : 
     BaseCompositeDeviceConfiguration(MOUSE_REPORT_ID),

--- a/MouseDevice.cpp
+++ b/MouseDevice.cpp
@@ -25,7 +25,7 @@ MouseDevice::MouseDevice(const MouseConfiguration& config):
 
 void MouseDevice::init(NimBLEHIDDevice* hid)
 {
-    setCharacteristics(hid->inputReport(_config.getReportId()), nullptr);
+    setCharacteristics(hid->getInputReport(_config.getReportId()), nullptr);
 }
 
 const BaseCompositeDeviceConfiguration* MouseDevice::getDeviceConfig() const

--- a/README.md
+++ b/README.md
@@ -8,9 +8,13 @@ This library will let your ESP32 microcontroller behave as a bluetooth mouse, ke
 Published under the MIT license. Please see license.txt.
 
 ## Dependencies
- - Nimble-Arduino. Use the latest Github version from commit [a79941c](https://github.com/h2zero/NimBLE-Arduino/commit/a79941cc9e77ed60136ee385b1c73d89c847bd94) onwards. Do not use 1.4.2 from the Arduino library manager.
- -  Callback. Available from the Arduino library manager or [here](https://github.com/tomstewart89/Callback).
+ - Nimble-Arduino. Actual version support Nimble-Arduino-2.1.2
+ - Callback. Available from the Arduino library manager or [here](https://github.com/tomstewart89/Callback).
 
+## Optional dependencies
+ - Keypad 
+ - Bounce2
+   
 ## XInput gamepad features
 
  - [x] All buttons and joystick axes available

--- a/XboxGamepadDevice.cpp
+++ b/XboxGamepadDevice.cpp
@@ -82,11 +82,11 @@ XboxGamepadDevice::~XboxGamepadDevice() {
 
 void XboxGamepadDevice::init(NimBLEHIDDevice* hid) {
     /// Create input characteristic to send events to the computer
-    auto input = hid->inputReport(XBOX_INPUT_REPORT_ID);
-    //_extra_input = hid->inputReport(XBOX_EXTRA_INPUT_REPORT_ID);
+    auto input = hid->getInputReport(XBOX_INPUT_REPORT_ID);
+    //_extra_input = hid->getInputReport(XBOX_EXTRA_INPUT_REPORT_ID);
 
     // Create output characteristic to handle events coming from the computer
-    auto output = hid->outputReport(XBOX_OUTPUT_REPORT_ID);
+    auto output = hid->getOutputReport(XBOX_OUTPUT_REPORT_ID);
     _callbacks = new XboxGamepadCallbacks(this);
     output->setCallbacks(_callbacks);
 


### PR DESCRIPTION
Add autobuild to test (except one due to esp_base_mac_addr_set being disable in BleGamepad.cpp )

Added "#include \<stdexcept\>" in [GamepadDevice.cpp](https://github.com/Mystfit/ESP32-BLE-CompositeHID/compare/master...grimlokason:ESP32-BLE-CompositeHID:master?expand=1#diff-2c9e83811282cfe005dbf5368fea8b2fbf0429e3981d412412fd9a91b3d16819) because i was unable to build without it on some computer ( even if it was working on github actions... )

More important part : the build against nimble arduino 2.1.2 is ok thanks to the work from @Sab1e-GitHub on @lemmingDev's project 