### PR TITLE
Change appearance to HID_GAMEPAD for BlueRetro compatibility

### DIFF
--- a/BleCompositeHID.cpp
+++ b/BleCompositeHID.cpp
@@ -277,7 +277,7 @@ void BleCompositeHID::taskServer(void *pvParameter)
 
     // Start BLE advertisement
     NimBLEAdvertising *pAdvertising = pServer->getAdvertising();
-    pAdvertising->setAppearance(GENERIC_HID);
+    pAdvertising->setAppearance(HID_GAMEPAD);
     pAdvertising->addServiceUUID(BleCompositeHIDInstance->_hid->getHidService()->getUUID());
     pAdvertising->start();
     ESP_LOGD(LOG_TAG, "Advertising started!");


### PR DESCRIPTION
Updated the device appearance configuration to use setAppearance(HID_GAMEPAD). This change improves compatibility with BlueRetro. Tested and verified the correct functionality after the modification.