### PR TITLE
Add library.json for PlatformIO

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,72 @@
+{
+    "$schema": "https://raw.githubusercontent.com/platformio/platformio-core/develop/platformio/assets/schema/library.json",
+    "name": "ESP32-BLE-CompositeHID",
+    "version": "0.3.1",
+    "description": "Bluetooth LE Gamepad + Mouse + Keyboard library for the ESP32",
+    "keywords": [
+        "Communication"
+    ],
+    "homepage": "https://github.com/Mystfit/ESP32-BLE-CompositeHID",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Mystfit/ESP32-BLE-CompositeHID.git"
+    },
+    "authors": [
+        {
+            "name": "Mystfit",
+            "maintainer": true,
+            "url": "https://github.com/mystfit"
+        }
+    ],
+    "license": "Apache-2.0",
+    "frameworks": [
+        "Arduino"
+    ],
+    "platforms": [
+        "espressif32"
+    ],
+    "headers": [
+        "BleCompositeHID.h",
+        "GamepadDevice.h",
+        "KeyboardDevice.h",
+        "MouseDevice.h",
+        "XboxGamepadDevice.h"
+    ],
+    "examples": [
+        {
+            "name": "GamepadMouseKeyboard",
+            "base": "examples/MultipleDeviceExamples/GamepadMouseKeyboard",
+            "files": [
+                "GamepadMouseKeyboard.ino"
+            ]
+        },
+        {
+            "name": "Gamepad",
+            "base": "examples/GamepadExamples/Gamepad",
+            "files": [
+                "Gamepad.ino"
+            ]
+        }
+    ],
+    "dependencies": [
+        {
+            "name": "NimBLE-Arduino",
+            "version": "^2.3.6",
+            "owner": "h2zero"
+        },
+        {
+            "name": "Callback",
+            "owner": "tomstewart89",
+            "version": "^1.1"
+        }
+    ],
+    "build": {
+        "srcDir": ".",
+        "srcFilter": [
+            "+<./*.c>",
+            "+<./*.cpp>",
+            "+<./*.h>",
+            "-<examples/**/*>"
+        ]
+    }
+}

--- a/library.json
+++ b/library.json
@@ -18,7 +18,7 @@
             "url": "https://github.com/mystfit"
         }
     ],
-    "license": "Apache-2.0",
+    "license": "MIT",
     "frameworks": [
         "Arduino"
     ],


### PR DESCRIPTION
Adding a library.json makes the library fully compatible with the PlatformIO registry/dependency management system.

Currently in `platformio.ini` you can add the URL to this repo to draw it in.
```ini
[env]
; <--snip-->
lib_deps = 
    https://github.com/Mystfit/ESP32-BLE-CompositeHID#v0.3.1
```

But this spits out a warning:
```
Library Manager: ESP32-BLE-CompositeHID@0.3.1+sha.fc2716b has been installed!
Library Manager: Resolving dependencies...
Library Manager: Installing NimBLE-Arduino
Downloading 0% 10% 20% 30% 40% 50% 60% 70% 80% 90% 100%
Unpacking 0% 10% 20% 30% 40% 50% 60% 70% 80% 90% 100%
Library Manager: NimBLE-Arduino@2.3.6 has been installed!
Library Manager: Installing Callback
Library Manager: Warning! More than one package has been found by Callback requirements:
Library Manager:  - tomstewart89/Callback@1.1
Library Manager:  - harry-obrien/Callback@1.0.0
Library Manager:  - pippijn/Callback@0.1
Library Manager: Please specify detailed REQUIREMENTS using package owner and version (shown above) to avoid name conflicts
```

I've added a `library.json` file which, among other goodies, explicitly specifies which `Callback` package is required. Tested locally with PlatformIO, and it builds properly. PlatformIO prioritizes `library.json`, while Arduino's Library Manager prioritizes `library.properties`, so nothing should break in the Arduino IDE.

The other motivator is that this package can be uploaded to the [PlatformIO Registry](https://registry.platformio.org).