### PR TITLE
Add BLE connection params to host config

### DIFF
--- a/BLEHostConfiguration.cpp
+++ b/BLEHostConfiguration.cpp
@@ -14,7 +14,11 @@ BLEHostConfiguration::BLEHostConfiguration() :
     _hardwareRevision("1.0.0"),
     _systemID(""),
     _deferSendRate(240),
-    _threadedAutoSend(false)
+    _threadedAutoSend(false),
+    _minConnectionInterval(6),
+    _maxConnectionInterval(7),
+    _slaveLatency(0),
+    _supervisionTimeout(600)
 {               
 }
 
@@ -48,3 +52,15 @@ uint32_t BLEHostConfiguration::getQueueSendRate() const { return _deferSendRate;
 
 void BLEHostConfiguration::setQueuedSending(bool value) { _threadedAutoSend = value; }
 bool BLEHostConfiguration::getQueuedSending() const { return _threadedAutoSend; }
+
+void BLEHostConfiguration::setMinConnectionInterval(uint16_t value) { _minConnectionInterval = value; }
+uint16_t BLEHostConfiguration::getMinConnectionInterval() const { return _minConnectionInterval; }
+
+void BLEHostConfiguration::setMaxConnectionInterval(uint16_t value) { _maxConnectionInterval = value; }
+uint16_t BLEHostConfiguration::getMaxConnectionInterval() const { return _maxConnectionInterval; }
+
+void BLEHostConfiguration::setSlaveLatency(uint16_t value) { _slaveLatency = value; }
+uint16_t BLEHostConfiguration::getSlaveLatency() const { return _slaveLatency; }
+
+void BLEHostConfiguration::setSupervisionTimeout(uint16_t value) { _supervisionTimeout = value; }
+uint16_t BLEHostConfiguration::getSupervisionTimeout() const { return _supervisionTimeout; }

--- a/BLEHostConfiguration.h
+++ b/BLEHostConfiguration.h
@@ -17,6 +17,10 @@ private:
     uint16_t _pid;
 	uint16_t _guidVersion;
     uint16_t _hid_type;
+    uint16_t _minConnectionInterval;
+    uint16_t _maxConnectionInterval;
+    uint16_t _slaveLatency;
+    uint16_t _supervisionTimeout;
     std::string _modelNumber;
     std::string _softwareRevision;
     std::string _serialNumber;
@@ -48,6 +52,15 @@ public:
     void setSerialNumber(const char *value);
     void setFirmwareRevision(const char *value);
     void setHardwareRevision(const char *value);
+
+    void setMinConnectionInterval(uint16_t value);
+    uint16_t getMinConnectionInterval() const;
+    void setMaxConnectionInterval(uint16_t value);
+    uint16_t getMaxConnectionInterval() const;
+    void setSlaveLatency(uint16_t value);
+    uint16_t getSlaveLatency() const;
+    void setSupervisionTimeout(uint16_t value);
+    uint16_t getSupervisionTimeout() const;
 
     // Set how quickly the auto-send should send queued reports. 
     // A value of 0 will send reports as soon as they are queued.

--- a/BleCompositeHID.cpp
+++ b/BleCompositeHID.cpp
@@ -186,6 +186,7 @@ void BleCompositeHID::taskServer(void *pvParameter)
     pServer->setCallbacks(BleCompositeHIDInstance->_connectionStatus);
     pServer->advertiseOnDisconnect(true);
     BleCompositeHIDInstance->_hid = new NimBLEHIDDevice(pServer);
+    BleCompositeHIDInstance->_connectionStatus->setConfiguration(&BleCompositeHIDInstance->_configuration);
     
     // Setup the HID descriptor buffers
     size_t totalBufferSize = 2048;
@@ -280,6 +281,7 @@ void BleCompositeHID::taskServer(void *pvParameter)
     // Start BLE advertisement
     NimBLEAdvertising *pAdvertising = pServer->getAdvertising();
     pAdvertising->setAppearance(hidType);
+    pAdvertising->setName(BleCompositeHIDInstance->deviceName);
     pAdvertising->addServiceUUID(BleCompositeHIDInstance->_hid->getHidService()->getUUID());
     pAdvertising->start();
     ESP_LOGD(LOG_TAG, "Advertising started!");

--- a/BleCompositeHID.cpp
+++ b/BleCompositeHID.cpp
@@ -182,6 +182,8 @@ void BleCompositeHID::taskServer(void *pvParameter)
     //uint8_t newMACAddress[] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF - 0x02};
     //esp_base_mac_addr_set(&newMACAddress[0]); // Set new MAC address 
     NimBLEDevice::init(BleCompositeHIDInstance->deviceName);
+    //Set the 2M PHY as default for tx and rx. Should be safe to add since if there's no compatibility or unrealibility the bt adapter on the host will re-negotiate this.
+	NimBLEDevice::setDefaultPhy(BLE_GAP_LE_PHY_2M_MASK, BLE_GAP_LE_PHY_2M_MASK);
     NimBLEServer *pServer = NimBLEDevice::createServer();
     pServer->setCallbacks(BleCompositeHIDInstance->_connectionStatus);
     pServer->advertiseOnDisconnect(true);

--- a/BleConnectionStatus.cpp
+++ b/BleConnectionStatus.cpp
@@ -1,12 +1,29 @@
 #include "BleConnectionStatus.h"
 
-BleConnectionStatus::BleConnectionStatus(void)
+BleConnectionStatus::BleConnectionStatus(void) : _configuration(nullptr)
 {
+}
+
+void BleConnectionStatus::setConfiguration(const BLEHostConfiguration* config)
+{
+    _configuration = config;
 }
 
 void BleConnectionStatus::onConnect(NimBLEServer *pServer, NimBLEConnInfo& connInfo)
 {
-    pServer->updateConnParams(connInfo.getConnHandle(), 6, 7, 0, 600);
+    uint16_t minInterval = 6;
+    uint16_t maxInterval = 7;
+    uint16_t latency = 0;
+    uint16_t timeout = 600;
+    
+    if (_configuration) {
+        minInterval = _configuration->getMinConnectionInterval();
+        maxInterval = _configuration->getMaxConnectionInterval();
+        latency = _configuration->getSlaveLatency();
+        timeout = _configuration->getSupervisionTimeout();
+    }
+
+    pServer->updateConnParams(connInfo.getConnHandle(), minInterval, maxInterval, latency, timeout);
 }
 
 void BleConnectionStatus::onDisconnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo, int reason)

--- a/BleConnectionStatus.cpp
+++ b/BleConnectionStatus.cpp
@@ -1,4 +1,5 @@
 #include "BleConnectionStatus.h"
+#include "BLEHostConfiguration.h"
 
 BleConnectionStatus::BleConnectionStatus(void) : _configuration(nullptr)
 {

--- a/BleConnectionStatus.h
+++ b/BleConnectionStatus.h
@@ -10,10 +10,13 @@
 #include "NimBLECharacteristic.h"
 #include "NimBLEConnInfo.h"
 
+class BLEHostConfiguration; // Forward declaration
+
 class BleConnectionStatus : public NimBLEServerCallbacks
 {
 public:
     BleConnectionStatus(void);
+    void setConfiguration(const BLEHostConfiguration* config);
     void onConnect(NimBLEServer *pServer, NimBLEConnInfo& connInfo) override;
     void onDisconnect(NimBLEServer *pServer, NimBLEConnInfo& connInfo, int reason) override;
     //NimBLECharacteristic *inputGamepad;
@@ -21,6 +24,7 @@ public:
     void onAuthenticationComplete(NimBLEConnInfo& connInfo) override;
 private:
     bool connected = false;
+    const BLEHostConfiguration* _configuration;
 };
 
 #endif // CONFIG_BT_NIMBLE_ROLE_PERIPHERAL


### PR DESCRIPTION
Introduce configurable BLE connection parameters into BLEHostConfiguration (min/max connection interval, slave latency, supervision timeout) with defaults initialized in the constructor and getters/setters added. BleConnectionStatus now holds a pointer to the configuration and uses those values when calling updateConnParams on connect (falls back to defaults if config is null). BleCompositeHID sets the connection-status configuration and also sets the advertising name.

Default 2M PHY are now used by default for higher polling rates.

Tested with ESP32 and ESP32-S3, now the device name is shown in windows bluetooth device search window, polling performance when using the default connection intervals is unchanged.

Thanks to @YeaSeb, @grimlokason, and @EmileSpecialProducts for their ideas for these changes.