### PR TITLE
Arduino size deltas workflow failure fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,9 @@ jobs:
             - name: Bounce2
             - source-path: .
 
-      - name: Sketches report size delta
-        uses: arduino/report-size-deltas@v1
-        # Only run the action when the workflow is triggered by a pull request.
+      - name: Upload sketches report
         if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: sketches-report-${{ github.event.pull_request.number }}
+          path: sketches-reports

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -1,0 +1,18 @@
+name: Report Size Deltas
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+  actions: read
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: arduino/report-size-deltas@v1
+        with:
+          sketches-reports-source: ^sketches-report-.*

--- a/BleCompositeHID.cpp
+++ b/BleCompositeHID.cpp
@@ -4,7 +4,6 @@
 #include "NimBLEHIDDevice.h"
 #include "HIDTypes.h"
 #include "HIDKeyboardTypes.h"
-#include <driver/adc.h>
 #include "sdkconfig.h"
 
 #include "BleCompositeHID.h"


### PR DESCRIPTION
PRs from forks can't get write tokens, so the action fails by design when run directly on pull_request. 

Adding an action that runs on a cron schedule rather than on the PR itself. The compile workflow runs on pull_request and uploads the sketches report as an artifact; a separate scheduled workflow periodically scans for those artifacts and posts the comments. Because scheduled workflows run in the base repo's context, they always have write permissions regardless of where the PR came from.